### PR TITLE
Made track method callback return response data as second argument

### DIFF
--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -33,9 +33,9 @@ function _postToApi(token, data, cb) {
         var name = data.user_id || data.device_id;
         console.error('There was a problem tracking "'
           + data.event_type + '" for "' + name + '"; ' + err);
-        cb(err);
+        cb(err, res.body);
       } else if(cb) {
-        cb(res.body)
+        cb(null, res.body);
       }
     });
 }


### PR DESCRIPTION
`track` method was passing the response body back as the first argument to callback. This made it more complex to differentiate errors from successes in callback and was not a standard node-like callback.

Now with two callback arguments the `amplitude.track` method is also more promisify-friendly (ie with `var trackPromise = Bluebird.promisify(amplitude.track, amplitude)`).
