### PR TITLE
Added support for the Amplitude Identify API

### DIFF
--- a/amplitude.js
+++ b/amplitude.js
@@ -41,6 +41,16 @@ Amplitude.prototype._postEvent = function (data) {
     .then(res => res.body)
 }
 
+Amplitude.prototype._identifyUser = function (data) {
+  return request.post('https://api.amplitude.com/identify')
+    .set('Accept', 'application/json')
+    .send({
+      api_key: this.token,
+      identification: data
+    })
+    .then(res => res.body)
+}
+
 Amplitude.prototype._getExport = function (data) {
   return request.get('https://amplitude.com/api/2/export')
     .auth(this.token, this.secretKey)
@@ -48,6 +58,21 @@ Amplitude.prototype._getExport = function (data) {
       start: data.start,
       end: data.end
     })
+}
+
+Amplitude.prototype.identify = function (data) {
+  var sendData = Object.keys(data).reduce(function (obj, key) {
+    var transformedKey = camelCaseToSnakeCasePropertyMap[key] || key
+
+    obj[transformedKey] = data[key]
+
+    return obj
+  }, {})
+
+  sendData.user_id = sendData.user_id || this.userId
+  sendData.device_id = sendData.device_id || this.deviceId
+
+  return this._identifyUser(sendData)
 }
 
 Amplitude.prototype.track = function (data) {

--- a/test/identify.test.js
+++ b/test/identify.test.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const nock = require('nock')
+const Amplitude = require('../amplitude')
+
+function generateMockedRequest (identity, status) {
+  let mockedRequest = nock('https://api.amplitude.com')
+    .defaultReplyHeaders({ 'Content-Type': 'application/json' })
+    .post('/identify', {
+      api_key: 'token',
+      identification: identity
+    })
+    .reply(status, { some: 'data' })
+
+  return mockedRequest
+}
+
+describe('identify', function () {
+  beforeEach(function () {
+    this.amplitude = new Amplitude('token', {
+      user_id: 'unique_user_id',
+      device_id: 'unique_device_id'
+    })
+
+    this.data = {
+      city: 'Brooklyn',
+      paying: false,
+      user_properties: {
+        likes_chocolate: true
+      }
+    }
+
+    this.id = {
+      user_id: 'unique_user_id',
+      device_id: 'unique_device_id',
+      city: 'Brooklyn',
+      paying: false,
+      user_properties: {
+        likes_chocolate: true
+      }
+    }
+  })
+
+  it('resolves when the request succeeds', function () {
+    let mockedRequest = generateMockedRequest(this.id, 200)
+
+    return this.amplitude.identify(this.data).then((res) => {
+      expect(res).to.eql({ some: 'data' })
+      mockedRequest.done()
+    }).catch((err) => {
+      expect(err).to.not.exist
+    })
+  })
+
+  it('can override the user id set on initialization', function () {
+    this.id.device_id = 'unique_device_id';
+    this.id.user_id = 'another_user_id';
+    this.data.user_id = 'another_user_id';
+
+    let mockedRequest = generateMockedRequest(this.id, 200)
+
+    return this.amplitude.identify(this.data).then((res) => {
+      expect(res).to.eql({ some: 'data' })
+      mockedRequest.done()
+    }).catch((err) => {
+      expect(err).to.not.exist
+    })
+  })
+
+  it('can override the device id set on initialization', function () {
+    this.id.device_id = 'another_device_id';
+    this.id.user_id = 'unique_user_id';
+    this.data.device_id = 'another_device_id'
+
+    let mockedRequest = generateMockedRequest(this.id, 200)
+
+    return this.amplitude.identify(this.data).then((res) => {
+      expect(res).to.eql({ some: 'data' })
+      mockedRequest.done()
+    }).catch((err) => {
+      expect(err).to.not.exist
+    })
+  })
+
+  it('rejects when the request fails', function () {
+    let mockedRequest = generateMockedRequest(this.id, 500)
+
+    return this.amplitude.identify(this.data)
+      .then((res) => {
+        throw new Error('should not resolve')
+      }).catch((err) => {
+        expect(err.status).to.eql(500)
+        expect(err.message).to.eql('Internal Server Error')
+        mockedRequest.done()
+      })
+  })
+})


### PR DESCRIPTION
From the docs
(https://amplitude.zendesk.com/hc/en-us/articles/205406617):

Send a POST or GET request to https://api.amplitude.com/identify with
two request parameters:
- api_key
- identification

Keys for the identification block:
- user_id (string)
- device_id (string)
- user_properties (dictionary of arbitrary key-value pairs)

`user_properties` allows you to slice and dice users into cohorts.
