### PR TITLE
send POST fields in track()

### DIFF
--- a/amplitude.js
+++ b/amplitude.js
@@ -65,11 +65,18 @@ Amplitude.prototype.identify = function (data) {
 Amplitude.prototype.track = function (data) {
   var transformedData = this._generateRequestData(data)
 
+  var params = {
+    api_key: this.token,
+    event: JSON.stringify(transformedData)
+  };
+
+  var encodedParams = Object.keys(params).map((key) => {
+    return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+  }).join('&');
+
   return request.post(AMPLITUDE_TOKEN_ENDPOINT + '/httpapi')
-    .query({
-      api_key: this.token,
-      event: JSON.stringify(transformedData)
-    })
+    .send(encodedParams)
+    .type('application/x-www-form-urlencoded')
     .set('Accept', 'application/json')
     .then(function (res) {
       return res.body


### PR DESCRIPTION
Sending the event data as GET you can run into a limit.

I switched it to post fields, since sending application/json triggers the CORS preflight. Amplitude's server doesn't handle OPTIONS requests :(