### PR TITLE
Add eventSegmentation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,7 @@ amplitude.eventSegmentation({
 Example response:
 
 ```javascript
-{
-  { series: [ [ 2, 25, 3, 1, 0, 0, 2, 3, 5, 1, 0, 0, 0, 0 ] ],
+{ series: [ [ 2, 25, 3, 1, 0, 0, 2, 3, 5, 1, 0, 0, 0, 0 ] ],
   seriesLabels: [ 0 ],
   xValues: 
    [ '2017-01-04',
@@ -261,7 +260,6 @@ Example response:
      '2017-01-15',
      '2017-01-16',
      '2017-01-17' ] }
-}
 ```
 
 If the event does not exist, Amplitude will throw a 400 error.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,53 @@ amplitude.userSearch('user-id').then(function (res) {
 })
 ```
 
+### Event Segmentation
+
+The event segmentation method requires your [secret key](https://amplitude.zendesk.com/hc/en-us/articles/206728448-Where-can-I-find-my-app-s-API-Key-or-Secret-Key-) to be added when initializing the amplitude object. This method uses the [dashboard api](https://amplitude.zendesk.com/hc/en-us/articles/205469748-Dashboard-Rest-API-Export-Amplitude-Dashboard-Data#event-segmentation).
+
+Get metrics for an event with segmentation.
+
+```javascript
+var amplitude = new Amplitude('api-token', { secretKey: 'secret' })
+
+amplitude.eventSegmentation({
+  e: {
+    'event_type': 'event_name'
+  },
+  start: '20170104',
+  end: '20170117',
+})
+.then((res) => {
+  var segmentationData = res.data
+})
+```
+
+Example response:
+
+```javascript
+{
+  { series: [ [ 2, 25, 3, 1, 0, 0, 2, 3, 5, 1, 0, 0, 0, 0 ] ],
+  seriesLabels: [ 0 ],
+  xValues: 
+   [ '2017-01-04',
+     '2017-01-05',
+     '2017-01-06',
+     '2017-01-07',
+     '2017-01-08',
+     '2017-01-09',
+     '2017-01-10',
+     '2017-01-11',
+     '2017-01-12',
+     '2017-01-13',
+     '2017-01-14',
+     '2017-01-15',
+     '2017-01-16',
+     '2017-01-17' ] }
+}
+```
+
+If the event does not exist, Amplitude will throw a 400 error.
+
 ## Changelog
 
 View the [releases page](https://github.com/crookedneighbor/amplitude/releases) for changes in each version.

--- a/amplitude.js
+++ b/amplitude.js
@@ -143,4 +143,26 @@ Amplitude.prototype.userActivity = function (amplitudeId, data) {
     })
 }
 
+Amplitude.prototype.eventSegmentation = function (data) {
+  if (!this.secretKey) {
+    throw new Error('secretKey must be set to use the eventSegmentation method')
+  }
+
+  if (!data.e || !data.start || !data.end) {
+    throw new Error('`e`, `start` and `end` are required data properties')
+  }
+
+  if (typeof data.e === 'object') {
+    data.e = JSON.stringify(data.e)
+  }
+
+  return request.get(AMPLITUDE_DASHBOARD_ENDPOINT + '/events/segmentation')
+    .auth(this.token, this.secretKey)
+    .query(data)
+    .set('Accept', 'application/json')
+    .then(function (res) {
+      return res.body
+    })
+}
+
 module.exports = Amplitude

--- a/test/event-segmentation.test.js
+++ b/test/event-segmentation.test.js
@@ -1,0 +1,96 @@
+'use strict'
+
+const Amplitude = require('../amplitude')
+const nock = require('nock')
+
+function generateMockedRequest (query, response, status) {
+  query.e = JSON.stringify(query.e)
+
+  return nock('https://amplitude.com')
+    .defaultReplyHeaders({'Content-Type': 'application/json'})
+    .get('/api/2/events/segmentation')
+    .query(query)
+    .basicAuth({
+      user: 'token',
+      pass: 'key'
+    })
+    .reply(status, response)
+}
+
+describe('eventSegmentation', function () {
+  beforeEach(function () {
+    this.amplitude = new Amplitude('token', {
+      secretKey: 'key'
+    })
+    this.data = {
+      e: {
+        event_type: 'mock_event'
+      },
+      start: '20160523T20',
+      end: '20160525T20'
+    }
+    this.response = {
+      series: [ [ 2, 25, 3 ] ],
+      seriesLabels: [ 0 ],
+      xValues:
+        [ '2017-01-15',
+          '2017-01-16',
+          '2017-01-17' ]
+    }
+  })
+
+  it('throws an error if secret key is missing', function () {
+    delete this.amplitude.secretKey
+
+    expect(() => {
+      this.amplitude.eventSegmentation(this.data)
+    }).to.throw('secretKey must be set to use the eventSegmentation method')
+  });
+
+  it('throws an error if e param is missing', function () {
+    delete this.data.e
+
+    expect(() => {
+      this.amplitude.eventSegmentation(this.data)
+    }).to.throw('`e`, `start` and `end` are required data properties')
+  });
+
+  it('throws an error if start param is missing', function () {
+    delete this.data.start
+
+    expect(() => {
+      this.amplitude.eventSegmentation(this.data)
+    }).to.throw('`e`, `start` and `end` are required data properties')
+  });
+
+  it('throws an error if end param is missing', function () {
+    delete this.data.end
+
+    expect(() => {
+      this.amplitude.eventSegmentation(this.data)
+    }).to.throw('`e`, `start` and `end` are required data properties')
+  });
+
+  it('rejects with error 400 when segmentation event does not exist', function () {
+    this.data.e.event_type = 'event_no_exist'
+    let mockedRequest = generateMockedRequest(this.data, null, 400)
+
+    return this.amplitude.eventSegmentation(this.data).then((res) => {
+      throw new Error('Should not have resolved')
+    }).catch((err) => {
+      expect(err.status).to.eql(400);
+      mockedRequest.done()
+    });
+  });
+
+  it('resolves with series and xValues if the segmentation event is found', function () {
+    let mockedRequest = generateMockedRequest(this.data, this.response, 200)
+
+    return this.amplitude.eventSegmentation(this.data).then((res) => {
+      expect(res).to.eql(this.response)
+      mockedRequest.done()
+    }).catch((err) => {
+      expect(err).to.not.exist
+    })
+  })
+})


### PR DESCRIPTION
This adds an endpoint to query for event segmentation as described here: https://amplitude.zendesk.com/hc/en-us/articles/205469748-Dashboard-Rest-API-Export-Amplitude-Dashboard-Data#event-segmentation

The way it would be used:

```javascript
amplitude
.eventSegmentation({
  e: {
    'event_type': 'event_name'
  },
  start: '20170104',
  end: '20170117',
})
.then((res) => {
  console.log(res.data);
})
.catch((err) => {
  console.error('err', err);
});
```

Note that this stringifies `e` as required by Amplitude.