### PR TITLE
Allow passing an array of identity and event objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,41 @@ var data = {
 amplitude.track(data)
 ```
 
+You can also pass an array of `event` objects:
+```javascript
+var data = [
+  {
+    event_type: 'some value', // required
+    user_id: 'some id', // only required if device id is not passed in
+    device_id: 'some id', // only required if user id is not passed in
+    event_properties: {
+      //...
+    },
+    user_properties: {
+      //...
+    }
+  },
+  {
+    event_type: 'another value', // required
+    user_id: 'some id', // only required if device id is not passed in
+    device_id: 'some id', // only required if user id is not passed in
+    event_properties: {
+      //...
+    },
+    user_properties: {
+      //...
+    }
+  }
+]
+amplitude.identify(data)
+```
+
 ## Identify API
 
 The `identify` method allows you to [make changes to a user without sending an analytics event](https://amplitude.zendesk.com/hc/en-us/articles/205406617). 
 
 ```javascript
 var data = {
-  event_type: 'some value', // required
   user_id: 'some id', // only required if device id is not passed in
   device_id: 'some id', // only required if user id is not passed in
   event_properties: {
@@ -53,6 +81,33 @@ var data = {
     //...
   }
 }
+amplitude.identify(data)
+```
+
+You can also pass an array of `identify` objects:
+```javascript
+var data = [
+  {
+    user_id: 'some id', // only required if device id is not passed in
+    device_id: 'some id', // only required if user id is not passed in
+    event_properties: {
+      //...
+    },
+    user_properties: {
+      //...
+    }
+  },
+  {
+    user_id: 'some id', // only required if device id is not passed in
+    device_id: 'some id', // only required if user id is not passed in
+    event_properties: {
+      //...
+    },
+    user_properties: {
+      //...
+    }
+  }
+]
 amplitude.identify(data)
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var data = [
     }
   }
 ]
-amplitude.identify(data)
+amplitude.track(data)
 ```
 
 ## Identify API

--- a/amplitude.js
+++ b/amplitude.js
@@ -59,12 +59,20 @@ Amplitude.prototype._generateRequestData = function (data) {
 Amplitude.prototype.identify = function (data) {
   var transformedData = this._generateRequestData(data)
 
+  var params = {
+    api_key: this.token,
+    identification: JSON.stringify(transformedData)
+  }
+
+  var encodedParams = Object.keys(params).map(function (key) {
+    return encodeURIComponent(key) + '=' + encodeURIComponent(params[key])
+  }).join('&')
+
   return request.post(AMPLITUDE_TOKEN_ENDPOINT + '/identify')
+    .send(encodedParams)
+    .type('application/x-www-form-urlencoded')
     .set('Accept', 'application/json')
-    .query({
-      api_key: this.token,
-      identification: JSON.stringify(transformedData)
-    }).then(function (res) {
+    .then(function (res) {
       return res.body
     })
 }

--- a/amplitude.js
+++ b/amplitude.js
@@ -35,18 +35,25 @@ function Amplitude (token, options) {
 }
 
 Amplitude.prototype._generateRequestData = function (data) {
-  var transformedData = Object.keys(data).reduce(function (obj, key) {
-    var transformedKey = camelCaseToSnakeCasePropertyMap[key] || key
+  var passedDataIsArray = Array.isArray(data)
+  var arrayedData = passedDataIsArray ? data : [data]
 
-    obj[transformedKey] = data[key]
+  var transformedDataArray = arrayedData.map(function (item) {
+    var transformedData = Object.keys(item).reduce(function (obj, key) {
+      var transformedKey = camelCaseToSnakeCasePropertyMap[key] || key
 
-    return obj
-  }, {})
+      obj[transformedKey] = item[key]
 
-  transformedData.user_id = transformedData.user_id || this.userId
-  transformedData.device_id = transformedData.device_id || this.deviceId
+      return obj
+    }, {})
 
-  return transformedData
+    transformedData.user_id = transformedData.user_id || this.userId
+    transformedData.device_id = transformedData.device_id || this.deviceId
+
+    return transformedData
+  }, this)
+
+  return passedDataIsArray ? transformedDataArray : transformedDataArray[0]
 }
 
 Amplitude.prototype.identify = function (data) {

--- a/test/identify.test.js
+++ b/test/identify.test.js
@@ -123,4 +123,49 @@ describe('identify', function () {
         mockedRequest.done()
       })
   })
+
+  it('can accept an array of identity objects', function () {
+    this.identity = [{
+      city: 'Brooklyn',
+      paying: false,
+      user_properties: {
+        likes_chocolate: true
+      },
+      user_id: 'unique_user_id',
+      device_id: 'unique_device_id'
+    },
+    {
+      city: 'Brooklyn',
+      paying: false,
+      user_properties: {
+        likes_chocolate: true
+      },
+      user_id: 'unique_user_id',
+      device_id: 'unique_device_id'
+    }]
+
+    this.data = [{
+      city: 'Brooklyn',
+      paying: false,
+      user_properties: {
+        likes_chocolate: true
+      }
+    },
+    {
+      city: 'Brooklyn',
+      paying: false,
+      user_properties: {
+        likes_chocolate: true
+      }
+    }]
+
+    let mockedRequest = generateMockedRequest(this.identity, 200)
+
+    return this.amplitude.identify(this.data).then((res) => {
+      expect(res).to.eql({ some: 'data' })
+      mockedRequest.done()
+    }).catch((err) => {
+      expect(err).to.not.exist
+    })
+  })
 })

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -132,4 +132,15 @@ describe('track', function () {
         mockedRequest.done()
       })
   })
+
+  it('can accept an array of event objects', function () {
+    let mockedRequest = generateMockedRequest([this.event], 200)
+
+    return this.amplitude.track([this.data]).then((res) => {
+      expect(res).to.eql({ some: 'data' })
+      mockedRequest.done()
+    }).catch((err) => {
+      expect(err).to.not.exist
+    })
+  })
 })


### PR DESCRIPTION
The Amplitude API allows passing an array of event/identity objects, but the `_generateRequestData` method was iterating over the array, so you'd end up with:
```
{ 0: {
  event_type: 'some event',
  device_id: 'unique_id'
}}
```

I also removed the `event_type` from the Identify section of the README as that parameter isn't recognized by Amplitude.