### PR TITLE
Allow passing of sessionId in camel case, optionally in constructor opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This is the full list of properties that will be automatically transformed:
 ```
 userId -> user_id
 deviceId -> device_id
-deviceId -> session_id
+sessionId -> session_id
 eventType -> event_type
 eventProperties -> event_properties
 userProperties -> user_properties
@@ -151,7 +151,7 @@ locationLat -> location_lat
 locationLng -> location_lng
 ```
 
-### User/Device ID
+### User/Device/Session ID
 
 If the user/device/session id will always be the same, you can initialize the object with it. Passing a user id or device id in the `track` and `identify` methods will override the default value set at initialization.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ var data = {
   event_type: 'some value', // required
   user_id: 'some id', // only required if device id is not passed in
   device_id: 'some id', // only required if user id is not passed in
+  session_id: 1492789357923, // must be unix timestamp in ms, not required
   event_properties: {
     //...
   },
@@ -120,6 +121,7 @@ var data = {
   eventType: 'some value', // required
   userId: 'some id', // only required if device id is not passed in
   deviceId: 'some id', // only required if user id is not passed in
+  sessionId: 1492789357923, // must be unix timestamp in ms, not required
   eventProperties: {
     //...
   },
@@ -135,6 +137,7 @@ This is the full list of properties that will be automatically transformed:
 ```
 userId -> user_id
 deviceId -> device_id
+deviceId -> session_id
 eventType -> event_type
 eventProperties -> event_properties
 userProperties -> user_properties
@@ -150,12 +153,14 @@ locationLng -> location_lng
 
 ### User/Device ID
 
-If the user/device id will always be the same, you can initialize the object with it. Passing a user id or device id in the `track` and `identify` methods will override the default value set at initialization.
+If the user/device/session id will always be the same, you can initialize the object with it. Passing a user id or device id in the `track` and `identify` methods will override the default value set at initialization.
 
 ```javascript
 var amplitude = new Amplitude('api-token', { user_id: 'some-user-id' })
 // or
 var amplitude = new Amplitude('api-token', { device_id: 'some-device-id' })
+// or
+var amplitude = new Amplitude('api-token', { session_id: 1492789357923 })
 
 amplitude.track({
   event_type: 'some value'
@@ -333,3 +338,4 @@ Do not change anything below this comment. It is generated automatically.
 + [Matthew Keesan](http://keesan.net)
 + [Geoff Dutton](undefined)
 + [Matt Pardee](undefined)
++ [Chase Seibert](http://chase-seibert.github.io/blog/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://travis-ci.org/crookedneighbor/amplitude.svg?branch=master) ![npm version](https://badge.fury.io/js/amplitude.svg)
 
-Server side implimentation of [Amplitude](https://amplitude.com)'s http api.
+Server side implementation of [Amplitude](https://amplitude.com)'s http api.
 
 ## Install
 

--- a/amplitude.js
+++ b/amplitude.js
@@ -33,7 +33,7 @@ function Amplitude (token, options) {
   this.secretKey = options.secretKey
   this.userId = options.userId || options.user_id
   this.deviceId = options.deviceId || options.device_id
-  this.sessionId = options.sessionId || options.sessionId
+  this.sessionId = options.sessionId || options.session_id
 }
 
 Amplitude.prototype._generateRequestData = function (data) {

--- a/amplitude.js
+++ b/amplitude.js
@@ -8,6 +8,7 @@ var AMPLITUDE_DASHBOARD_ENDPOINT = 'https://amplitude.com/api/2'
 var camelCaseToSnakeCasePropertyMap = Object.freeze({
   userId: 'user_id',
   deviceId: 'device_id',
+  sessionId: 'session_id',
   eventType: 'event_type',
   eventProperties: 'event_properties',
   userProperties: 'user_properties',
@@ -32,6 +33,7 @@ function Amplitude (token, options) {
   this.secretKey = options.secretKey
   this.userId = options.userId || options.user_id
   this.deviceId = options.deviceId || options.device_id
+  this.sessionId = options.sessionId || options.sessionId
 }
 
 Amplitude.prototype._generateRequestData = function (data) {
@@ -49,6 +51,7 @@ Amplitude.prototype._generateRequestData = function (data) {
 
     transformedData.user_id = transformedData.user_id || this.userId
     transformedData.device_id = transformedData.device_id || this.deviceId
+    transformedData.session_id = transformedData.session_id || this.sessionId
 
     return transformedData
   }, this)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     {
       "name": "Chase Seibert",
       "email": "chase.seibert@gmail.com"
-    },
+    }
   ],
   "scripts": {
     "prepublish-please": "npm test",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     {
       "name": "Matt Pardee",
       "email": "matt.pardee@gmail.com"
-    }
+    },
+    {
+      "name": "Chase Seibert",
+      "email": "chase.seibert@gmail.com"
+    },
   ],
   "scripts": {
     "prepublish-please": "npm test",

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -56,4 +56,22 @@ describe('initialization', () => {
 
     expect(amplitude.secretKey).to.eql('secret')
   })
+
+  it('sets sessionId when specified', () => {
+    let amplitude = new Amplitude('token', { sessionId: 'db_session_id' })
+
+    expect(amplitude.sessionId).to.eql('db_session_id')
+  })
+
+  it('can use session_id to set sessionId', () => {
+    let amplitude = new Amplitude('token', { session_id: 'db_session_id' })
+
+    expect(amplitude.sessionId).to.eql('db_session_id')
+  })
+
+  it('prefers sessionId over session_id to set sessionId', () => {
+    let amplitude = new Amplitude('token', { sessionId: 'sessionId', session_id: 'session_id' })
+
+    expect(amplitude.sessionId).to.eql('sessionId')
+  })
 })


### PR DESCRIPTION
Previously, passing sessionId would not pass the correct snake case
value to Amplitude. Because this value may not change over the life of
your amplitude client, allow passing as a constructor option.